### PR TITLE
use a base url

### DIFF
--- a/explore/index.html
+++ b/explore/index.html
@@ -28,7 +28,7 @@
 <main><p class="secondary loading">Loading...</p></main>
 
 <script type="module">
-  import { fetchCreations } from "/script/pondiverse.js";
+  import { fetchCreations, getCreationImageUrl } from "/script/pondiverse.js";
   import { getTypeUrl } from "/participants.js";
 
   const main = document.querySelector("main");
@@ -82,9 +82,7 @@
           }</h2>
           <img id="c${
             creation.id
-          }" src="https://todepond--56fe958021f911f0a9ab569c3dd06744.web.val.run/?c=${
-        creation.id
-      }" alt="${creation.title}" />
+          }" src="${getCreationImageUrl(creation.id)}" alt="${creation.title}" />
           <details>
             <summary>show data</summary>
             <pre class="data-preview"><code>${prettyData}</code></pre>

--- a/script/pondiverse.js
+++ b/script/pondiverse.js
@@ -11,7 +11,7 @@ export async function fetchCreations(page = 0) {
 }
 
 export async function updateDatabase() {
-  const response = await fetch(new URL("/creations", baseUrl));
+  const response = await fetch(new URL("/updateDatabase", baseUrl), { method: "POST" });
   const json = await response.json();
   if (!json.ok) throw new Error("Failed to update database");
   return json;

--- a/script/pondiverse.js
+++ b/script/pondiverse.js
@@ -17,6 +17,10 @@ export async function updateDatabase() {
   return json;
 }
 
+export function getCreationImageUrl(id) {
+  return new URL(`/creations?c=${id}`, baseUrl);
+}
+
 export function addPondiverseButton() {
   const style = `
 	.pondiverse-button-container {

--- a/script/pondiverse.js
+++ b/script/pondiverse.js
@@ -1,8 +1,8 @@
+export let baseURL = "TODO!!!";
+
 export async function fetchCreations(page = 0) {
   console.log("Fetching creations from page", page);
-  const response = await fetch(
-    `https://todepond--8d30672821b811f0b0cd569c3dd06744.web.val.run/?page=${page}`
-  );
+  const response = await fetch(new URL(`/creations?page=${page}`, baseUrl));
   const json = await response.json();
   if (!json.ok) throw new Error("Failed to fetch creations");
   const rows = json.rows;
@@ -11,9 +11,7 @@ export async function fetchCreations(page = 0) {
 }
 
 export async function updateDatabase() {
-  const response = await fetch(
-    `https://todepond--d60ba2a421b911f09a39569c3dd06744.web.val.run`
-  );
+  const response = await fetch(new URL("/creations", baseUrl));
   const json = await response.json();
   if (!json.ok) throw new Error("Failed to update database");
   return json;
@@ -229,7 +227,7 @@ export function addPondiverseButton() {
     publishButton.style.cursor = "not-allowed";
 
     const response = await fetch(
-      "https://todepond--e03ca2bc21bb11f094e3569c3dd06744.web.val.run",
+      new URL("/creations", baseUrl),
       {
         method: "POST",
         body: JSON.stringify(request),


### PR DESCRIPTION
It's hard to do some things (like prototype backend changes in a fork) when each method has its own subdomain.

This PR adds support for [this PR on val.town](https://www.val.town/x/todepond/pondiverse/pull/3c5b9984-243e-11f0-bc26-569c3dd06744), which is a simple routing implementation. If both that and this is merged, clients can change a single base url to switch to a different backend.

This is a draft PR because it needs val.town to generate a new base url, and that will only happen if the above PR is merged.