### PR TITLE
first iteration of "open in tool"

### DIFF
--- a/explore/index.html
+++ b/explore/index.html
@@ -28,7 +28,11 @@
 <main><p class="secondary loading">Loading...</p></main>
 
 <script type="module">
-  import { fetchCreations, getCreationImageUrl } from "/script/pondiverse.js";
+  import {
+    fetchCreations,
+    getCreationImageUrl,
+    getCreationUrlForTool,
+  } from "/script/pondiverse.js";
   import { getTypeUrl } from "/participants.js";
 
   const main = document.querySelector("main");
@@ -73,6 +77,12 @@
       }
 
       const url = getTypeUrl(creation.type);
+
+      let imageEl = `<img
+        id="c${creation.id}"
+        src="${getCreationImageUrl(creation.id)}"
+        alt="${creation.title}" />`;
+
       return `
         <div class="creation">
           <h2>${
@@ -80,9 +90,11 @@
               ? `${creation.title}, <a href=${url}>${creation.type}</a>`
               : `${creation.title}, ${creation.type}`
           }</h2>
-          <img id="c${
-            creation.id
-          }" src="${getCreationImageUrl(creation.id)}" alt="${creation.title}" />
+          ${
+            url
+              ? `<a title="open with ${url}" href="${getCreationUrlForTool(url, creation.id)}">${imageEl}</a>`
+              : imageEl
+          }
           <details>
             <summary>show data</summary>
             <pre class="data-preview"><code>${prettyData}</code></pre>

--- a/learn/index.html
+++ b/learn/index.html
@@ -83,4 +83,15 @@ window.getPondiverseCreation = () => {
 <p>We wil probably merge it without checking.</p>
 
 <p>If you're not happy using github you can send me message on the fediverse (mags@mags.omg.lol) and I'll do it for you.</p>
+
+<p>Each image posted from your tool will then become a link like this: <code>https://your.tool.url/?creation=123</code></p>. The <code>fetchCreation()</code> function can then use this id to fetch the creation for the tool to open:
+
+<pre>
+let creation = await fetchCreation().catch(() => null);
+if (creation && creation.type === "your-type") {
+    let data = JSON.parse(creation.data);
+    // ...
+}
+</pre>
+
 </details>

--- a/script/pondiverse.js
+++ b/script/pondiverse.js
@@ -17,8 +17,24 @@ export async function updateDatabase() {
   return json;
 }
 
+export function getCreationUrlForTool(toolUrl, id) {
+  let url = new URL(toolUrl);
+  url.searchParams.set("creation", id);
+  return url;
+}
+
 export function getCreationImageUrl(id) {
   return new URL(`/creations?c=${id}`, baseUrl);
+}
+
+// without an id, gets it from query param
+export async function fetchCreation(id) {
+  if (id === undefined) id = new URL(window.location).searchParams.get("creation");
+  if (id === null) throw new Error("no id in function params or query");
+  console.log("Fetching creation with id", id);
+  const response = await fetch(new URL(`/creations?json&c=${id}`, baseUrl));
+  if (!response.ok) throw new Error(response.statusText);
+  return await response.json();
 }
 
 export function addPondiverseButton() {


### PR DESCRIPTION
Depends on API introduced here: https://www.val.town/x/todepond/pondiverse/pull/63d195dc-2465-11f0-bacd-569c3dd06744

For now, uses `participants.js` to get tool urls, which binds one creation type to one tool, which isn't ideal. But the api itself allows for any tool url.

Resolves (part of?) #6 