### PR TITLE
split participants.js into tools and types

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -30,12 +30,11 @@
 
 <main>
   <script type="module">
-    import { getTypes } from "/participants.js";
-    const types = getTypes();
+    import participants from "/participants.js";
     const main = document.querySelector("main");
 
-    for (const type of types) {
-      main.innerHTML += ` <a href=${type.url} class="button secondary">${type.name}</a> `;
+    for (let tool of participants.tools) {
+      main.innerHTML += ` <a href=${tool.urls.create} class="button secondary">${tool.name}</a> `;
     }
   </script>
 </main>

--- a/create/index.html
+++ b/create/index.html
@@ -30,10 +30,10 @@
 
 <main>
   <script type="module">
-    import participants from "/participants.js";
+    import config from "/pondiverse.js";
     const main = document.querySelector("main");
 
-    for (let tool of participants.tools) {
+    for (let tool of config.tools) {
       main.innerHTML += ` <a href=${tool.urls.create} class="button secondary">${tool.name}</a> `;
     }
   </script>

--- a/explore/index.html
+++ b/explore/index.html
@@ -33,7 +33,7 @@
     getCreationImageUrl,
     getCreationUrlForTool,
   } from "/script/pondiverse.js";
-  import { getTypeUrl } from "/participants.js";
+  import participants from "/participants.js";
 
   const main = document.querySelector("main");
 
@@ -80,7 +80,9 @@
         prettyData = creation.data;
       }
 
-      const url = getTypeUrl(creation.type);
+      // TODO: unbind types from tools!!! very important
+      // TODO: glob list match here instead of equality
+      let tool = participants.tools.find((t) => t.types.creates === creation.type);
 
       let imageEl = `<img
         id="c${creation.id}"
@@ -90,13 +92,13 @@
       return `
         <div class="creation">
           <h2>${
-            url
-              ? `${creation.title}, <a href=${url}>${creation.type}</a>`
+            tool?.urls.create
+              ? `${creation.title}, <a href=${tool.urls.create}>${creation.type}</a>`
               : `${creation.title}, ${creation.type}`
           }</h2>
           ${
-            url
-              ? `<a title="open with ${url}" href="${getCreationUrlForTool(url, creation.id)}">${imageEl}</a>`
+            tool?.urls.open
+              ? `<a title="open with ${tool.name}" href="${tool.urls.open + creation.id}">${imageEl}</a>`
               : imageEl
           }
           <details>

--- a/explore/index.html
+++ b/explore/index.html
@@ -33,7 +33,7 @@
     getCreationImageUrl,
     getCreationUrlForTool,
   } from "/script/pondiverse.js";
-  import participants from "/participants.js";
+  import { config } from "/pondiverse.js";
 
   const main = document.querySelector("main");
 
@@ -82,7 +82,7 @@
 
       // TODO: unbind types from tools!!! very important
       // TODO: glob list match here instead of equality
-      let tool = participants.tools.find((t) => t.types.creates === creation.type);
+      let tool = config.tools.find((t) => t.types.creates === creation.type);
 
       let imageEl = `<img
         id="c${creation.id}"

--- a/learn/index.html
+++ b/learn/index.html
@@ -78,19 +78,22 @@ window.getPondiverseCreation = () => {
 
 <details>
 <summary>Secret bonus section: adding your tool to this website</summary>
-<p>If you are happy using github, you can make a pull request to the <code>participants.js</code> file. This contains one big object with the names of all the types, along with links to the primary tool that makes them. This list gets put on the <a href="/create/index.html">create page</a> and with the titles in the <a href="/explore/index.html">gallery</a>.</p>
+<p>If you are happy using github, you can make a pull request to the <code>participants.js</code> file. Describe your creation type (if it's a new one) in the <code>types</code> section, and your tool in the <code>tools</code> section.
 
 <p>We wil probably merge it without checking.</p>
 
 <p>If you're not happy using github you can send me message on the fediverse (mags@mags.omg.lol) and I'll do it for you.</p>
 
-<p>Each image posted from your tool will then become a link like this: <code>https://your.tool.url/?creation=123</code></p>. The <code>fetchCreation()</code> function can then use this id to fetch the creation for the tool to open:
+<p>pondiverse.com will use the <code>tool.urls.open</code> to open creations in your tool, by appending the creation id to it, then navigating to the resulting URL. The <code>fetchCreation()</code> function can then use this id to fetch the creation for the tool to open:</p>
 
 <pre>
-let creation = await fetchCreation().catch(() => null);
-if (creation && creation.type === "your-type") {
-    let data = JSON.parse(creation.data);
-    // ...
+let id = new URL(window.location).searchParams.get("id");
+if (id) {
+  let creation = await fetchCreation(id);
+  if (creation && creation.type === "your-type") {
+      let data = JSON.parse(creation.data);
+      // ...
+  }
 }
 </pre>
 

--- a/learn/index.html
+++ b/learn/index.html
@@ -78,7 +78,7 @@ window.getPondiverseCreation = () => {
 
 <details>
 <summary>Secret bonus section: adding your tool to this website</summary>
-<p>If you are happy using github, you can make a pull request to the <code>participants.js</code> file. Describe your creation type (if it's a new one) in the <code>types</code> section, and your tool in the <code>tools</code> section.
+<p>If you are happy using github, you can make a pull request to the <code>/pondiverse.js</code> file. Describe your creation type (if it's a new one) in the <code>types</code> section, and your tool in the <code>tools</code> section.
 
 <p>We wil probably merge it without checking.</p>
 

--- a/participants.js
+++ b/participants.js
@@ -1,27 +1,128 @@
-const participants = {
-  screenpond: { url: "https://screenpond.cool/" },
-  chaoskit: { url: "https://evolved.systems/chaoskit/" },
-  pnmrsimjs: { url: "https://mags.omg.lol/simulator.php" },
-  codepond: { url: "https://codepond.elouan.xyz/" },
-  cherry: { url: "https://cherry.cthulahoops.org/" },
-  collapse: { url: "https://collapse.cthulahoops.org/" },
-  bitart: { url: "https://iliazeus.lol/bitart/" },
-  'real-shader': { url: "https://garten.salat.dev/real-shaders.html" },
-  'fake-shader': { url: "https://garten.salat.dev/fake-shaders2.html" },
+export default {
+  types: {
+    screenpond: {
+      docs: "https://github.com/TodePond/ScreenPond",
+    },
+    chaoskit: {
+      docs: "https://github.com/ChaosKit/prototypes/tree/master/05-coffeescript",
+    },
+    pnmrsimjs: {
+      docs: "https://mags.omg.lol/simulator.php",
+    },
+    codepond: {
+      docs: "https://github.com/elouangrimm/CodePond",
+    },
+    cherry: {
+      docs: "https://cherry.cthulahoops.org/sketch.js",
+    },
+    collapse: {
+      docs: "https://collapse.cthulahoops.org/main.js",
+    },
+    bitart: {
+      docs: "https://iliazeus.lol/bitart/",
+    },
+    "real-shader": {
+      docs: "https://garten.salat.dev/real-shaders.html",
+    },
+    "fake-shader": {
+      docs: "https://garten.salat.dev/fake-shaders2.html",
+    },
+  },
+  tools: [
+    {
+      name: "ScreenPond",
+      types: {
+        // comma-separated glob list (glob matching not implemented yet)
+        creates: "screenpond",
+        // empty string means opens nothing (yet)
+        opens: "",
+      },
+      urls: {
+        create: "https://screenpond.cool/",
+      },
+    },
+    {
+      name: "ChaosKit",
+      types: {
+        creates: "chaoskit",
+        opens: "",
+      },
+      urls: {
+        create: "https://evolved.systems/chaoskit/",
+      },
+    },
+    {
+      name: "pNMRsimJS",
+      types: {
+        creates: "pnmrsimjs",
+        opens: "",
+      },
+      urls: {
+        create: "https://mags.omg.lol/simulator.php",
+      },
+    },
+    {
+      name: "CodePond",
+      types: {
+        creates: "codepond",
+        opens: "",
+      },
+      urls: {
+        create: "https://codepond.elouan.xyz/",
+      },
+    },
+    {
+      name: "cherry.cthulahoops.org",
+      types: {
+        creates: "cherry",
+        opens: "",
+      },
+      urls: {
+        create: "https://cherry.cthulahoops.org/",
+      },
+    },
+    {
+      name: "collapse.cthulahoops.org",
+      types: {
+        creates: "collapse",
+        opens: "",
+      },
+      urls: {
+        create: "https://collapse.cthulahoops.org/",
+      },
+    },
+    {
+      name: "BitArt",
+      types: {
+        creates: "bitart",
+        opens: "bitart",
+      },
+      urls: {
+        create: "https://iliazeus.lol/bitart/",
+        open: "https://iliazeus.lol/bitart/?creation=",
+      },
+    },
+    {
+      name: "real shaders",
+      types: {
+        creates: "real-shader",
+        opens: "real-shader",
+      },
+      urls: {
+        create: "https://garten.salat.dev/real-shaders.html",
+        open: "https://garten.salat.dev/real-shaders.html?creation=",
+      },
+    },
+    {
+      name: "faking shaders II",
+      types: {
+        creates: "fake-shader",
+        opens: "fake-shader",
+      },
+      urls: {
+        create: "https://garten.salat.dev/fake-shaders2.html",
+        open: "https://garten.salat.dev/fake-shaders2.html?creation=",
+      },
+    },
+  ],
 };
-
-export function getTypeUrl(type) {
-  type = type.toLowerCase();
-  return participants[type]?.url;
-}
-
-// TODO: no, this is bad. confusing different concepts here. `type` shoudl always be a string, not an object.
-// refactor, kill participants (participants are PEOPLE, not types or tools).
-export function getTypes() {
-  const types = [];
-  for (const type in participants) {
-    const participant = participants[type];
-    types.push({ name: type, url: participant.url });
-  }
-  return types;
-}

--- a/pondiverse.js
+++ b/pondiverse.js
@@ -1,4 +1,20 @@
 export default {
+  name: "pondiverse.com",
+
+  instances: [
+    {
+      name: "pondiverse.com",
+      urls: {
+        frontend: "https://pondiverse.com",
+        list: "https://todepond--33148208245911f0bc54569c3dd06744.web.val.run/creations?page=",
+        get: "https://todepond--33148208245911f0bc54569c3dd06744.web.val.run/creations?json&c=",
+        getImage:
+          "https://todepond--33148208245911f0bc54569c3dd06744.web.val.run/creation?c=",
+        post: "https://todepond--33148208245911f0bc54569c3dd06744.web.val.run/creations",
+      },
+    },
+  ],
+
   types: {
     screenpond: {
       docs: "https://github.com/TodePond/ScreenPond",
@@ -28,6 +44,7 @@ export default {
       docs: "https://garten.salat.dev/fake-shaders2.html",
     },
   },
+
   tools: [
     {
       name: "ScreenPond",

--- a/pondiverse.js
+++ b/pondiverse.js
@@ -6,6 +6,7 @@ export default {
       name: "pondiverse.com",
       urls: {
         frontend: "https://pondiverse.com",
+        config: "https://pondiverse.com/pondiverse.js",
         list: "https://todepond--33148208245911f0bc54569c3dd06744.web.val.run/creations?page=",
         get: "https://todepond--33148208245911f0bc54569c3dd06744.web.val.run/creations?json&c=",
         getImage:


### PR DESCRIPTION
Format docs links are the best I could find - mostly just links to source code, or to the tool itself if it explains something itself.

The `tool.types` are intended to be 

Resolves #44, but still keeps the 1-1 type-to-tool thing in the "open in tool" links, which is still bad and still needs to be changed.

Should also resolve #33.