### PR TITLE
add iliazeus.lol/puddle endpoints to instances.js

### DIFF
--- a/instances.js
+++ b/instances.js
@@ -7,10 +7,10 @@ export const instances = [
     getCreations: "https://pondiverse.val.run/get-creations",
   },
   {
-    name: "iliazeus.lol",
-    addCreation: "TODO",
-    getCreation: "TODO",
-    getCreationImage: "TODO",
-    getCreations: "TODO",
+    name: "iliazeus.lol/puddle",
+    addCreation: "https://iliazeus-puddle.web.val.run/creations/",
+    getCreation: "https://iliazeus-puddle.web.val.run/creations/",
+    getCreationImage: "TODO", // i have images as data URIs inside creations currently
+    getCreations: "https://iliazeus-puddle.web.val.run/creations/",
   },
 ];


### PR DESCRIPTION
My API is a bit different at the moment, though:

- `items` instead of `rows` in `getCreations`
- images as data URIs in creation objects; no separate image endpoint currently

I would actually like to change pondiverse.com API to be like this, not the other way around:

- `rows` seems a bit too specific (I don't have an actual database); `items` is more generic (or we can do `creations`, actually)
- right now pondiverse returns `image: null` which even looks a bit strange, and not symmetric with addCreation; we can put image urls there instead